### PR TITLE
Fix invalid syntax in module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -47,5 +47,5 @@
   ],
   "url": "Filled in by the release workflow",
   "manifest":"Filled in by the release workflow",
-  "download": "Filled in by the release workflow",
+  "download": "Filled in by the release workflow"
 }


### PR DESCRIPTION
Invalid syntax in line 50 module.json
The invalid syntax is causing the workflow to output YAML instead of JSON when it runs "Populate Versioned keys in Manifest"